### PR TITLE
Fixup in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Example usage:
 .. code:: python
 
   import matplotlib.pylab as plt
+  import numpy as np
   from katbeam import JimBeam
 
   def showbeam(beam,freqMHz=1000,pol='H',beamextent=10.):


### PR DESCRIPTION
In the README, the example lacks the numpy import. Obvious but still helpful for user that just want to copypaste the code.